### PR TITLE
Update prefix array spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ const App: React.FC = () => {
   const [usedRuts, setUsedRuts] = useState<string[]>([]);
 
   const generateRutList = () => {
-    const prefixes = [8, 15, 18, 20,22]; // Agregar prefijo 22
+    const prefixes = [8, 15, 18, 20, 22]; // Agregar prefijo 22
     const newRuts: Record<number, string[]> = {};
 
     prefixes.forEach((prefix) => {


### PR DESCRIPTION
## Summary
- fix spacing in prefix array and ensure prefix `22` is included

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d34f780a08331906df4902dfbf5b5