### PR TITLE
Add footer link to fake JSON generator

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,6 +3,18 @@ import React from 'react';
 const Footer: React.FC = () => (
   <footer className="bg-gray-200 text-center py-4 mt-6">
     <p className="text-sm text-gray-600">Generador de RUTs &copy; 2025 / bugaDev</p>
+    <p className="text-sm text-gray-600 mt-2">
+      Otras utilidades:
+      {' '}
+      <a
+        href="https://donbuga.github.io/fake-json-generator/"
+        className="text-blue-500 underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Fake json generator
+      </a>
+    </p>
   </footer>
 );
 


### PR DESCRIPTION
## Summary
- expand footer with link to the Fake JSON Generator

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d37feff0083318c399b75e5bb2c35