### PR TITLE
Add random number column

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,10 +13,14 @@ const App: React.FC = () => {
     22: [],
   });
   const [usedRuts, setUsedRuts] = useState<string[]>([]);
+  const [randomNumbers, setRandomNumbers] = useState<number[]>([]);
 
   const generateRutList = () => {
     const prefixes = [8, 15, 18, 20,22]; // Agregar prefijo 22
     const newRuts: Record<number, string[]> = {};
+    const newRandoms: number[] = Array.from({ length: 10 }, () =>
+      Math.floor(100000000 + Math.random() * 900000000)
+    );
 
     prefixes.forEach((prefix) => {
       newRuts[prefix] = Array.from({ length: 10 }, () => {
@@ -42,6 +46,7 @@ const App: React.FC = () => {
     });
 
     setRutsByPrefix(newRuts);
+    setRandomNumbers(newRandoms);
     setUsedRuts([]); // Resetear RUTs usados
   };
 
@@ -67,7 +72,12 @@ const App: React.FC = () => {
             Generar RUTs
           </button>
         </div>
-        <RutTable rutsByPrefix={rutsByPrefix} usedRuts={usedRuts} onCopy={copyToClipboard} />
+        <RutTable
+          rutsByPrefix={rutsByPrefix}
+          usedRuts={usedRuts}
+          randomNumbers={randomNumbers}
+          onCopy={copyToClipboard}
+        />
       </main>
       <Footer />
     </div>

--- a/src/components/RutTable.tsx
+++ b/src/components/RutTable.tsx
@@ -4,10 +4,16 @@ import { useMediaQuery } from 'react-responsive';
 interface RutTableProps {
   rutsByPrefix: Record<number, string[]>;
   usedRuts: string[];
+  randomNumbers: number[];
   onCopy: (rut: string) => void;
 }
 
-const RutTable: React.FC<RutTableProps> = ({ rutsByPrefix, usedRuts, onCopy }) => {
+const RutTable: React.FC<RutTableProps> = ({
+  rutsByPrefix,
+  usedRuts,
+  randomNumbers,
+  onCopy,
+}) => {
   const isMobile = useMediaQuery({ maxWidth: 768 });
   const prefixes = Object.keys(rutsByPrefix);
   const displayPrefixes = isMobile ? prefixes.slice(-3) : prefixes;
@@ -18,8 +24,14 @@ const RutTable: React.FC<RutTableProps> = ({ rutsByPrefix, usedRuts, onCopy }) =
         <thead className="bg-gray-200 text-gray-600">
           <tr>
             {displayPrefixes.map((prefix) => (
-              <th key={prefix} className="px-3 py-2 text-left text-sm md:text-base md:px-4">{`${prefix}xxxxxx-x`}</th>
+              <th
+                key={prefix}
+                className="px-3 py-2 text-left text-sm md:text-base md:px-4"
+              >{`${prefix}xxxxxx-x`}</th>
             ))}
+            <th className="px-3 py-2 text-left text-sm md:text-base md:px-4">
+              Número aleatorio
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -36,6 +48,9 @@ const RutTable: React.FC<RutTableProps> = ({ rutsByPrefix, usedRuts, onCopy }) =
                   {rutsByPrefix[parseInt(prefix)][rowIndex] || ''}
                 </td>
               ))}
+              <td className="px-3 py-2 border-t text-gray-800 text-sm md:text-base md:px-4">
+                {randomNumbers[rowIndex] || ''}
+              </td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- generate 10 random 9-digit numbers on each table refresh
- display these numbers in a new final column in `RutTable`

## Testing
- `npm test --silent --no-watch --no-color` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a2fe0980c8331ac25ddcd84125296