### PR TITLE
Add copy feature to random number column

### DIFF
--- a/src/components/RutTable.tsx
+++ b/src/components/RutTable.tsx
@@ -48,7 +48,13 @@ const RutTable: React.FC<RutTableProps> = ({
                   {rutsByPrefix[parseInt(prefix)][rowIndex] || ''}
                 </td>
               ))}
-              <td className="px-3 py-2 border-t text-gray-800 text-sm md:text-base md:px-4">
+              <td
+                className="px-3 py-2 border-t text-gray-800 text-sm md:text-base md:px-4 cursor-pointer"
+                onClick={() =>
+                  randomNumbers[rowIndex] !== undefined &&
+                  onCopy(randomNumbers[rowIndex].toString())
+                }
+              >
                 {randomNumbers[rowIndex] || ''}
               </td>
             </tr>


### PR DESCRIPTION
## Summary
- make random number cells clickable to copy

## Testing
- `npm install` *(fails: E403 403 Forbidden)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a425e55548331a5983d112670a460