### PR TITLE
Highlight random number cells after copy

### DIFF
--- a/src/components/RutTable.tsx
+++ b/src/components/RutTable.tsx
@@ -49,7 +49,11 @@ const RutTable: React.FC<RutTableProps> = ({
                 </td>
               ))}
               <td
-                className="px-3 py-2 border-t text-gray-800 text-sm md:text-base md:px-4 cursor-pointer"
+                className={`px-3 py-2 border-t text-gray-800 text-sm md:text-base md:px-4 cursor-pointer ${
+                  usedRuts.includes(randomNumbers[rowIndex]?.toString())
+                    ? 'bg-green-100'
+                    : ''
+                }`}
                 onClick={() =>
                   randomNumbers[rowIndex] !== undefined &&
                   onCopy(randomNumbers[rowIndex].toString())


### PR DESCRIPTION
## Summary
- highlight copied random number values the same as copied RUTs

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a4526926c8331baecd3d5140caa46