### PR TITLE
feat: add random email column

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders generar ruts button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const buttonElement = screen.getByText(/generar ruts/i);
+  expect(buttonElement).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,15 @@ import RutTable from './components/RutTable';
 import Footer from './components/Footer';
 import { generateRut, calculateDV } from './utils/rutUtils';
 
+const generateRandomEmail = (): string => {
+  const letters = Array.from({ length: 2 }, () =>
+    String.fromCharCode(97 + Math.floor(Math.random() * 26))
+  ).join('');
+  const numbers = Math.floor(1000 + Math.random() * 9000); // 4 dígitos
+  const domainNumbers = Math.floor(10 + Math.random() * 90); // 2 dígitos
+  return `${letters}${numbers}@${domainNumbers}.cl`;
+};
+
 const App: React.FC = () => {
   const [rutsByPrefix, setRutsByPrefix] = useState<Record<number, string[]>>({
     8: [],
@@ -14,6 +23,7 @@ const App: React.FC = () => {
   });
   const [usedRuts, setUsedRuts] = useState<string[]>([]);
   const [randomNumbers, setRandomNumbers] = useState<number[]>([]);
+  const [randomEmails, setRandomEmails] = useState<string[]>([]);
 
   const generateRutList = () => {
     const prefixes = [8, 15, 18, 20,22]; // Agregar prefijo 22
@@ -21,6 +31,7 @@ const App: React.FC = () => {
     const newRandoms: number[] = Array.from({ length: 10 }, () =>
       Math.floor(100000000 + Math.random() * 900000000)
     );
+    const newEmails: string[] = Array.from({ length: 10 }, generateRandomEmail);
 
     prefixes.forEach((prefix) => {
       newRuts[prefix] = Array.from({ length: 10 }, () => {
@@ -47,6 +58,7 @@ const App: React.FC = () => {
 
     setRutsByPrefix(newRuts);
     setRandomNumbers(newRandoms);
+    setRandomEmails(newEmails);
     setUsedRuts([]); // Resetear RUTs usados
   };
 
@@ -76,6 +88,7 @@ const App: React.FC = () => {
           rutsByPrefix={rutsByPrefix}
           usedRuts={usedRuts}
           randomNumbers={randomNumbers}
+          randomEmails={randomEmails}
           onCopy={copyToClipboard}
         />
       </main>

--- a/src/components/RutTable.tsx
+++ b/src/components/RutTable.tsx
@@ -5,6 +5,7 @@ interface RutTableProps {
   rutsByPrefix: Record<number, string[]>;
   usedRuts: string[];
   randomNumbers: number[];
+  randomEmails: string[];
   onCopy: (rut: string) => void;
 }
 
@@ -12,6 +13,7 @@ const RutTable: React.FC<RutTableProps> = ({
   rutsByPrefix,
   usedRuts,
   randomNumbers,
+  randomEmails,
   onCopy,
 }) => {
   const isMobile = useMediaQuery({ maxWidth: 768 });
@@ -31,6 +33,9 @@ const RutTable: React.FC<RutTableProps> = ({
             ))}
             <th className="px-3 py-2 text-left text-sm md:text-base md:px-4">
               Número aleatorio
+            </th>
+            <th className="px-3 py-2 text-left text-sm md:text-base md:px-4">
+              Email aleatorio
             </th>
           </tr>
         </thead>
@@ -60,6 +65,18 @@ const RutTable: React.FC<RutTableProps> = ({
                 }
               >
                 {randomNumbers[rowIndex] || ''}
+              </td>
+              <td
+                className={`px-3 py-2 border-t text-gray-800 text-sm md:text-base md:px-4 cursor-pointer ${
+                  usedRuts.includes(randomEmails[rowIndex])
+                    ? 'bg-green-100'
+                    : ''
+                }`}
+                onClick={() =>
+                  randomEmails[rowIndex] && onCopy(randomEmails[rowIndex])
+                }
+              >
+                {randomEmails[rowIndex] || ''}
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- add random email generator
- display and copy random emails in table

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_6893aa8bffd48331a79613c98a152254