### PR TITLE
Ensure random numbers start with 98

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ const App: React.FC = () => {
     const prefixes = [8, 15, 18, 20,22]; // Agregar prefijo 22
     const newRuts: Record<number, string[]> = {};
     const newRandoms: number[] = Array.from({ length: 10 }, () =>
-      Math.floor(100000000 + Math.random() * 900000000)
+      Math.floor(980000000 + Math.random() * 10000000)
     );
     const newEmails: string[] = generateRandomEmails(10);
 


### PR DESCRIPTION
## Summary
- Generate random numbers with a 98 prefix while keeping a nine-digit length

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af3359938c8331aab53fb78cad163e