### PR TITLE
Add RUT prefix 25 to App base structure and generation list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,13 +29,14 @@ const App: React.FC = () => {
     18: [],
     20: [],
     22: [],
+    25: [],
   });
   const [usedRuts, setUsedRuts] = useState<string[]>([]);
   const [randomNumbers, setRandomNumbers] = useState<number[]>([]);
   const [randomEmails, setRandomEmails] = useState<string[]>([]);
 
   const generateRutList = () => {
-    const prefixes = [8, 15, 18, 20,22]; // Agregar prefijo 22
+    const prefixes = [8, 15, 18, 20, 22, 25];
     const newRuts: Record<number, string[]> = {};
     const newRandoms: number[] = Array.from({ length: 10 }, () =>
       Math.floor(980000000 + Math.random() * 10000000)


### PR DESCRIPTION
### Motivation
- Add prefix `25` to the base RUT groups so the UI will generate and display the `25xxxxxx-x` group with its 10 rows.

### Description
- Added `25: []` to the initial `rutsByPrefix` state in `src/App.tsx` and updated `generateRutList`'s `prefixes` from `[8, 15, 18, 20, 22]` to `[8, 15, 18, 20, 22, 25]`.

### Testing
- Ran `npm run -s build`, which failed in this environment due to `react-scripts: not found`, and no further automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c44a49b8d88331bd7dd00cdf2107a7)