### PR TITLE
Agregar toast global centrado “Copiado” con animación retro de desvanecimiento

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Header from './components/Header';
 import RutTable from './components/RutTable';
 import Footer from './components/Footer';
@@ -35,6 +35,8 @@ const App: React.FC = () => {
   const [randomNumbers, setRandomNumbers] = useState<number[]>([]);
   const [randomEmails, setRandomEmails] = useState<string[]>([]);
   const [showAgeTable, setShowAgeTable] = useState(false);
+  const [copyToastVisible, setCopyToastVisible] = useState(false);
+  const copyToastTimeoutRef = useRef<number | null>(null);
 
   const ageRanges = [
     { rutRange: '8M – 9M', age: '64–70' },
@@ -104,18 +106,38 @@ const App: React.FC = () => {
     setUsedRuts([]); // Resetear RUTs usados
   };
 
-  React.useEffect(() => {
-  generateRutList();
+  useEffect(() => {
+    generateRutList();
+
+    return () => {
+      if (copyToastTimeoutRef.current) {
+        window.clearTimeout(copyToastTimeoutRef.current);
+      }
+    };
   }, []);
 
   const copyToClipboard = (rut: string) => {
     navigator.clipboard.writeText(rut).then(() => {
       setUsedRuts((prev) => [...prev, rut]);
+      setCopyToastVisible(false);
+
+      if (copyToastTimeoutRef.current) {
+        window.clearTimeout(copyToastTimeoutRef.current);
+      }
+
+      window.requestAnimationFrame(() => {
+        setCopyToastVisible(true);
+      });
+
+      copyToastTimeoutRef.current = window.setTimeout(() => {
+        setCopyToastVisible(false);
+        copyToastTimeoutRef.current = null;
+      }, 1100);
     });
   };
 
   return (
-    <div className="font-sans text-gray-800 bg-gray-100 min-h-screen">
+    <div className="font-sans text-gray-800 bg-gray-100 min-h-screen relative">
       <Header />
       <main className="p-6">
         <div className="text-center mb-6">
@@ -168,6 +190,11 @@ const App: React.FC = () => {
         </div>
       </main>
       <Footer />
+      <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none" aria-hidden="true">
+        <span className={copyToastVisible ? 'copy-toast-message copy-toast-message--active' : 'copy-toast-message'}>
+          Copiado
+        </span>
+      </div>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -16,3 +18,38 @@ code {
     monospace;
 }
 
+.copy-toast-message {
+  opacity: 0;
+  color: #fff6a9;
+  font-family: 'Press Start 2P', monospace;
+  font-size: clamp(1.4rem, 5.2vw, 3.2rem);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-shadow:
+    0 2px 0 #7f1d1d,
+    0 0 6px #f97316,
+    0 0 18px rgba(251, 191, 36, 0.85),
+    2px 2px 0 #312e81;
+  user-select: none;
+}
+
+.copy-toast-message--active {
+  animation: copyFadeOut 1.1s ease forwards;
+}
+
+@keyframes copyFadeOut {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  70% {
+    opacity: 0.85;
+    transform: translateY(-6px) scale(1.01);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(-14px) scale(1.04);
+  }
+}


### PR DESCRIPTION
### Motivation
- Mostrar una retroalimentación visual centrada al usuario cuando copia un RUT y asegurar que la animación se reinicie correctamente en clics rápidos.
- Aplicar un estilo 8‑bit retro coherente con la UI usando una tipografía pixel y sombras multilayer para énfasis temporal.

### Description
- Añadido estado y control de timeout en `src/App.tsx`: `copyToastVisible` y `copyToastTimeoutRef` para gestionar la visibilidad y reinicio de la animación en `copyToClipboard`.
- `copyToClipboard` ahora activa el toast tras `navigator.clipboard.writeText`, limpia el timeout previo, re-activa la animación con `requestAnimationFrame` y oculta el toast automáticamente después de ~1.1s.
- Se añadió limpieza del timeout en el `useEffect` de desmontaje para evitar timers colgando al salir del componente.
- Renderizado un overlay fijo centrado y no interactivo (`fixed inset-0 z-50 flex items-center justify-center pointer-events-none`, `aria-hidden="true"`) con el texto `Copiado` al final del JSX raíz.
- Estilos globales en `src/index.css`: import de `Press Start 2P` vía `@import`, clase `.copy-toast-message` con `font-family`, `clamp(...)` para tamaño responsive, `text-shadow` multilayer y la animación `@keyframes copyFadeOut` aplicada en `.copy-toast-message--active`.

### Testing
- Ejecutado `npm run build` en el contenedor y la compilación falló por entorno: `sh: 1: react-scripts: not found`, por lo que no se pudo completar una build integrada aquí.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c451832ea48331aacc1d45947a1615)