### PR TITLE
Update “Copiado” toast to blue and enhance upward fade-out motion

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,16 +20,16 @@ code {
 
 .copy-toast-message {
   opacity: 0;
-  color: #fff6a9;
+  color: #2563eb;
   font-family: 'Press Start 2P', monospace;
   font-size: clamp(1.4rem, 5.2vw, 3.2rem);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   text-shadow:
-    0 2px 0 #7f1d1d,
-    0 0 6px #f97316,
-    0 0 18px rgba(251, 191, 36, 0.85),
-    2px 2px 0 #312e81;
+    0 2px 0 #1e3a8a,
+    0 0 6px #3b82f6,
+    0 0 18px rgba(37, 99, 235, 0.55),
+    2px 2px 0 #172554;
   user-select: none;
 }
 
@@ -44,12 +44,12 @@ code {
   }
 
   70% {
-    opacity: 0.85;
-    transform: translateY(-6px) scale(1.01);
+    opacity: 0.8;
+    transform: translateY(-12px) scale(1.02);
   }
 
   100% {
     opacity: 0;
-    transform: translateY(-14px) scale(1.04);
+    transform: translateY(-28px) scale(1.05);
   }
 }


### PR DESCRIPTION
## Summary
- changed the `Copiado` toast text color from yellow to Tailwind `blue-600` (`#2563eb`)
- updated text-shadow accents to blue tones so the effect matches the new color palette
- increased vertical translation during `copyFadeOut` so the text clearly moves upward while fading out

## Files
- `src/index.css`

## Notes
- no runtime tests were executed (style-only adjustment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5440bdc388331aa3a95a36c3793dd)